### PR TITLE
fix: replace invalid workflow reference with GitHub CLI call

### DIFF
--- a/.github/workflows/rollout-health-monitor.yml
+++ b/.github/workflows/rollout-health-monitor.yml
@@ -61,10 +61,12 @@ jobs:
           
       - name: Trigger emergency rollback if needed
         if: failure()
-        uses: ./.github/workflows/rollout-emergency-rollback.yml
-        with:
-          reason: 'Health monitor detected critical issues'
-          triggered_by: 'automated_health_check'
+        run: |
+          gh workflow run rollout-emergency-rollback.yml \
+            -f reason="Health monitor detected critical issues" \
+            -f triggered_by="automated_health_check"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           
       - name: Upload health report
         if: always()


### PR DESCRIPTION
Replace local workflow reference with proper gh workflow run command to resolve action configuration error in rollout health monitor.

🤖 Generated with [Claude Code](https://claude.ai/code)