### PR TITLE
fix: prevent undefined length errors in rollout health checker

### DIFF
--- a/ops/src/lib/components/RecentJobs.svelte
+++ b/ops/src/lib/components/RecentJobs.svelte
@@ -72,7 +72,7 @@
   }
 
   function truncateError(error: string | null, maxLength = 50) {
-    if (!error) return '-';
+    if (!error || typeof error !== 'string') return '-';
     return error.length > maxLength ? error.substring(0, maxLength) + '...' : error;
   }
 </script>

--- a/ops/src/routes/api/sse/+server.ts
+++ b/ops/src/routes/api/sse/+server.ts
@@ -46,7 +46,7 @@ export const GET: RequestHandler = async ({ url }) => {
             .order('created_at', { ascending: false })
             .limit(100);
             
-          if (!error && jobs) {
+          if (!error && jobs && Array.isArray(jobs)) {
             // Calculate metrics
             const total = {
               pending: jobs.filter(j => j.status === 'pending').length,


### PR DESCRIPTION
Add Array.isArray check in SSE server and type guard in RecentJobs component to prevent "Cannot read property 'length' of undefined" errors when Supabase queries return unexpected data.

🤖 Generated with [Claude Code](https://claude.ai/code)